### PR TITLE
added css properties to keep title length to one line.

### DIFF
--- a/src/app/user/list/user-list.component.html
+++ b/src/app/user/list/user-list.component.html
@@ -80,7 +80,7 @@
                           <div class="card-metainfo col m6">
                             <p class="user-title">{{user.title}}</p>
                           </div>
-                          <div class="card-metainfo col m6 user-country">
+                          <div class="card-metainfo col m6">
                             <!--<span class="card-location float: right" *ngIf="user.country">{{user.country}}</span>-->
                             <span class="card-location float: right" *ngIf="user.state">{{user.state}}, {{user.country}}</span>
                             <span class="card-location float: right" *ngIf="!user.state">

--- a/src/app/user/list/user-list.component.html
+++ b/src/app/user/list/user-list.component.html
@@ -78,9 +78,9 @@
                         </div>
                         <div class="row">
                           <div class="card-metainfo col m6">
-                            <p>{{user.title}}</p>
+                            <p class="user-title">{{user.title}}</p>
                           </div>
-                          <div class="card-metainfo col m6">
+                          <div class="card-metainfo col m6 user-country">
                             <!--<span class="card-location float: right" *ngIf="user.country">{{user.country}}</span>-->
                             <span class="card-location float: right" *ngIf="user.state">{{user.state}}, {{user.country}}</span>
                             <span class="card-location float: right" *ngIf="!user.state">

--- a/src/app/user/list/user-list.component.scss
+++ b/src/app/user/list/user-list.component.scss
@@ -49,6 +49,3 @@
   text-overflow: ellipsis;
   white-space: nowrap;
 }
-
-
-

--- a/src/app/user/list/user-list.component.scss
+++ b/src/app/user/list/user-list.component.scss
@@ -44,3 +44,11 @@
   text-transform:uppercase;
 }
 
+.user-title {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+
+


### PR DESCRIPTION
@robbiejaeger
@ds_storoz

This pull request fixes #1728.  The issue requested that the title be on one line only.  We created a new class that had not been used in other parts of the project, `.user-title.` We added the following three css properties to fix the issue: 

``` 
.user-title {
  overflow: hidden;
  text-overflow: ellipsis;
  white-space: nowrap;
}
```

Before:

<img width="729" alt="screen shot 2017-12-05 at 1 55 11 pm" src="https://user-images.githubusercontent.com/24993521/33630272-f742eeaa-d9c3-11e7-8435-6caf13b0ea40.png">

After:

<img width="727" alt="screen shot 2017-12-05 at 1 53 31 pm" src="https://user-images.githubusercontent.com/24993521/33630283-fdbeb2d2-d9c3-11e7-9783-677039a7f163.png">
