### PR TITLE
fix issue where buttoms were overlapping

### DIFF
--- a/src/app/home/home.component.html
+++ b/src/app/home/home.component.html
@@ -363,7 +363,7 @@
 </div>
 <div class="section no-padding">
   <div class="green-ribbon white-text ribbon-padding-top">
-    <div class="row">
+    <div class="row button-container">
       <div class="col s12 padding">
         A platform by volunteers, for volunteers<br>        
       </div>      

--- a/src/app/home/home.component.scss
+++ b/src/app/home/home.component.scss
@@ -635,6 +635,21 @@ agm-map {
     
 }
 
+@media screen and (max-width: 670px) {
+  .button-container {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+  }
+  .row .col.s6 {
+    width: 100%;
+    margin-left: auto;
+    margin-right: auto;
+    left: auto;
+    right: auto;
+  }
+}
+
 @media screen and (max-width: 650px) {
    
     .aniSlogan-background{


### PR DESCRIPTION
@ds_storoz
@robbiegreiner 

This addresses issue #1724 button overlapping.  We added a media query at 670px to fix this issue

Before:

<img width="314" alt="before" src="https://user-images.githubusercontent.com/24993521/33739493-8a9f5d86-db5a-11e7-8f51-cdd346da45c9.png">


After:

<img width="395" alt="after" src="https://user-images.githubusercontent.com/24993521/33739523-a28984c6-db5a-11e7-958c-a993cd40c093.png">
